### PR TITLE
broadcast NewPresAnnFileAvailableMsg to html5

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/presentationpod/PresentationWithAnnotationsMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/presentationpod/PresentationWithAnnotationsMsgHdlr.scala
@@ -32,6 +32,16 @@ trait PresentationWithAnnotationsMsgHdlr extends RightsManagementTrait {
     BbbCommonEnvCoreMsg(envelope, event)
   }
 
+  def buildBroadcastNewPresAnnFileAvailable(newPresAnnFileAvailableMsg: NewPresAnnFileAvailableMsg, liveMeeting: LiveMeeting): BbbCommonEnvCoreMsg = {
+    val routing = Routing.addMsgToClientRouting(MessageTypes.BROADCAST_TO_MEETING, liveMeeting.props.meetingProp.intId, "not-used")
+    val envelope = BbbCoreEnvelope(PresentationPageConvertedEventMsg.NAME, routing)
+    val header = BbbClientMsgHeader(NewPresAnnFileAvailableEvtMsg.NAME, liveMeeting.props.meetingProp.intId, "not-used")
+    val body = NewPresAnnFileAvailableEvtMsgBody(fileURI = newPresAnnFileAvailableMsg.body.fileURI)
+    val event = NewPresAnnFileAvailableEvtMsg(header, body)
+
+    BbbCommonEnvCoreMsg(envelope, event)
+  }
+
   def buildPresentationUploadTokenSysPubMsg(parentId: String, userId: String, presentationUploadToken: String, filename: String): BbbCommonEnvCoreMsg = {
     val routing = collection.immutable.HashMap("sender" -> "bbb-apps-akka")
     val envelope = BbbCoreEnvelope(PresentationUploadTokenSysPubMsg.NAME, routing)
@@ -161,4 +171,12 @@ trait PresentationWithAnnotationsMsgHdlr extends RightsManagementTrait {
       bus.outGW.send(buildStoreAnnotationsInRedisSysMsg(annotations, liveMeeting))
     }
   }
+
+  def handle(m: NewPresAnnFileAvailableMsg, liveMeeting: LiveMeeting, bus: MessageBus): Unit = {
+    log.info("Received NewPresAnnFileAvailableMsg meetingId={} fileUrl={}", liveMeeting.props.meetingProp.intId, m.body.fileURI)
+
+    bus.outGW.send(buildBroadcastNewPresAnnFileAvailable(m, liveMeeting))
+
+  }
+
 }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
@@ -502,7 +502,7 @@ class MeetingActor(
       case m: AssignPresenterReqMsg                          => state = handlePresenterChange(m, state)
       case m: MakePresentationWithAnnotationDownloadReqMsg   => presentationPodsApp.handle(m, state, liveMeeting, msgBus)
       case m: ExportPresentationWithAnnotationReqMsg         => presentationPodsApp.handle(m, state, liveMeeting, msgBus)
-      case m: NewPresAnnFileAvailableMsg                     => log.info("***** New PDF with annotations available.")
+      case m: NewPresAnnFileAvailableMsg                     => presentationPodsApp.handle(m, liveMeeting, msgBus)
 
       // Presentation Pods
       case m: CreateNewPresentationPodPubMsg                 => state = presentationPodsApp.handle(m, state, liveMeeting, msgBus)

--- a/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/PresentationMsgs.scala
+++ b/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/PresentationMsgs.scala
@@ -22,6 +22,10 @@ object NewPresAnnFileAvailableMsg { val NAME = "NewPresAnnFileAvailableMsg" }
 case class NewPresAnnFileAvailableMsg(header: BbbClientMsgHeader, body: NewPresAnnFileAvailableMsgBody) extends StandardMsg
 case class NewPresAnnFileAvailableMsgBody(fileURI: String)
 
+object NewPresAnnFileAvailableEvtMsg { val NAME = "NewPresAnnFileAvailableEvtMsg" }
+case class NewPresAnnFileAvailableEvtMsg(header: BbbClientMsgHeader, body: NewPresAnnFileAvailableEvtMsgBody) extends BbbCoreMsg
+case class NewPresAnnFileAvailableEvtMsgBody(fileURI: String)
+
 // ------------ bbb-common-web to akka-apps ------------
 
 // ------------ akka-apps to client ------------

--- a/bigbluebutton-html5/imports/api/presentations/server/eventHandlers.js
+++ b/bigbluebutton-html5/imports/api/presentations/server/eventHandlers.js
@@ -15,4 +15,4 @@ RedisPubSub.on('PresentationConversionCompletedEvtMsg', handlePresentationAdded)
 RedisPubSub.on('RemovePresentationEvtMsg', handlePresentationRemove);
 RedisPubSub.on('SetCurrentPresentationEvtMsg', handlePresentationCurrentSet);
 RedisPubSub.on('SetPresentationDownloadableEvtMsg', handlePresentationDownloadableSet);
-RedisPubSub.on('NewPresAnnFileAvailableMsg', handlePresentationExport);
+RedisPubSub.on('NewPresAnnFileAvailableEvtMsg', handlePresentationExport);


### PR DESCRIPTION
Broadcast `NewPresAnnFileAvailableEvtMsg` to bbb-html5 when the export was successfully converted to PDF.

As quested in https://github.com/bigbluebutton/bigbluebutton/pull/15412.