### PR TITLE
Fix multiple pres. export; include presId in NewPresAnnFileAvailable

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/presentationpod/PresentationWithAnnotationsMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/presentationpod/PresentationWithAnnotationsMsgHdlr.scala
@@ -36,7 +36,7 @@ trait PresentationWithAnnotationsMsgHdlr extends RightsManagementTrait {
     val routing = Routing.addMsgToClientRouting(MessageTypes.BROADCAST_TO_MEETING, liveMeeting.props.meetingProp.intId, "not-used")
     val envelope = BbbCoreEnvelope(PresentationPageConvertedEventMsg.NAME, routing)
     val header = BbbClientMsgHeader(NewPresAnnFileAvailableEvtMsg.NAME, liveMeeting.props.meetingProp.intId, "not-used")
-    val body = NewPresAnnFileAvailableEvtMsgBody(fileURI = newPresAnnFileAvailableMsg.body.fileURI)
+    val body = NewPresAnnFileAvailableEvtMsgBody(fileURI = newPresAnnFileAvailableMsg.body.fileURI, presId = newPresAnnFileAvailableMsg.body.presId)
     val event = NewPresAnnFileAvailableEvtMsg(header, body)
 
     BbbCommonEnvCoreMsg(envelope, event)
@@ -82,24 +82,24 @@ trait PresentationWithAnnotationsMsgHdlr extends RightsManagementTrait {
     val userId = m.header.userId
 
     val presentationPods: Vector[PresentationPod] = state.presentationPodManager.getAllPresentationPodsInMeeting()
-    val currentPres: Option[PresentationInPod] = presentationPods.flatMap(_.getCurrentPresentation()).headOption
+    val presId: String = m.body.presId match {
+      case "" => PresentationPodsApp.getAllPresentationPodsInMeeting(state).flatMap(_.getCurrentPresentation.map(_.id)).mkString
+      case _  => m.body.presId
+    }
+
+    val currentPres: Option[PresentationInPod] = presentationPods.flatMap(_.getPresentation(presId)).headOption
 
     if (permissionFailed(PermissionCheck.MOD_LEVEL, PermissionCheck.VIEWER_LEVEL, liveMeeting.users2x, userId)) {
       val reason = "No permission to export presentation."
       PermissionCheck.ejectUserForFailedPermission(meetingId, userId, reason, bus.outGW, liveMeeting)
     } else if (currentPres.isEmpty) {
-      log.error(s"No presentation set in meeting ${meetingId}")
+      log.error(s"Presentation ${presId} not found in meeting ${meetingId}")
     } else {
 
       val jobType: String = "PresentationWithAnnotationDownloadJob"
       val jobId: String = RandomStringGenerator.randomAlphanumericString(16);
       val allPages: Boolean = m.body.allPages
       val pageCount = currentPres.get.pages.size
-
-      val presId: String = m.body.presId match {
-        case "" => PresentationPodsApp.getAllPresentationPodsInMeeting(state).flatMap(_.getCurrentPresentation.map(_.id)).mkString
-        case _  => m.body.presId
-      }
 
       val presLocation = List("var", "bigbluebutton", meetingId, meetingId, presId).mkString(File.separator, File.separator, "");
       val pages: List[Int] = m.body.pages // Desired presentation pages for export
@@ -173,7 +173,7 @@ trait PresentationWithAnnotationsMsgHdlr extends RightsManagementTrait {
   }
 
   def handle(m: NewPresAnnFileAvailableMsg, liveMeeting: LiveMeeting, bus: MessageBus): Unit = {
-    log.info("Received NewPresAnnFileAvailableMsg meetingId={} fileUrl={}", liveMeeting.props.meetingProp.intId, m.body.fileURI)
+    log.info("Received NewPresAnnFileAvailableMsg meetingId={} presId={} fileUrl={}", liveMeeting.props.meetingProp.intId, m.body.presId, m.body.fileURI)
 
     bus.outGW.send(buildBroadcastNewPresAnnFileAvailable(m, liveMeeting))
 

--- a/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/PresentationMsgs.scala
+++ b/bbb-common-message/src/main/scala/org/bigbluebutton/common2/msgs/PresentationMsgs.scala
@@ -20,11 +20,11 @@ case class ExportPresentationWithAnnotationReqMsgBody(parentMeetingId: String, a
 
 object NewPresAnnFileAvailableMsg { val NAME = "NewPresAnnFileAvailableMsg" }
 case class NewPresAnnFileAvailableMsg(header: BbbClientMsgHeader, body: NewPresAnnFileAvailableMsgBody) extends StandardMsg
-case class NewPresAnnFileAvailableMsgBody(fileURI: String)
+case class NewPresAnnFileAvailableMsgBody(fileURI: String, presId: String)
 
 object NewPresAnnFileAvailableEvtMsg { val NAME = "NewPresAnnFileAvailableEvtMsg" }
 case class NewPresAnnFileAvailableEvtMsg(header: BbbClientMsgHeader, body: NewPresAnnFileAvailableEvtMsgBody) extends BbbCoreMsg
-case class NewPresAnnFileAvailableEvtMsgBody(fileURI: String)
+case class NewPresAnnFileAvailableEvtMsgBody(fileURI: String, presId: String)
 
 // ------------ bbb-common-web to akka-apps ------------
 

--- a/bbb-export-annotations/workers/notifier.js
+++ b/bbb-export-annotations/workers/notifier.js
@@ -43,7 +43,8 @@ async function notifyMeetingActor() {
                 userId: ""
             },
             body: {
-                fileURI: link
+                fileURI: link,
+                presId: exportJob.presId
             },
           }
     }

--- a/bigbluebutton-html5/imports/api/presentations/server/handlers/presentationExport.js
+++ b/bigbluebutton-html5/imports/api/presentations/server/handlers/presentationExport.js
@@ -6,16 +6,11 @@ export default function handlePresentationExport({ body }, meetingId) {
   check(body, Object);
   check(meetingId, String);
 
-  const { fileURI } = body;
+  const { fileURI, presId } = body;
 
   check(fileURI, String);
+  check(presId, String);
 
-  const fileURL = new URL(fileURI);
-  const path = fileURL.pathname;
-  const presentationId = path.split('/')[5];
-
-  check(presentationId, String);
-
-  sendExportedPresentationChatMsg(meetingId, presentationId, fileURI);
-  setPresentationExporting(meetingId, presentationId, { status: 'EXPORTED' });
+  sendExportedPresentationChatMsg(meetingId, presId, fileURI);
+  setPresentationExporting(meetingId, presId, { status: 'EXPORTED' });
 }

--- a/bigbluebutton-html5/public/locales/en.json
+++ b/bigbluebutton-html5/public/locales/en.json
@@ -237,7 +237,7 @@
     "app.presentationUploader.exporting": "Sending to chat",
     "app.presentationUploader.sending": "Sending...",
     "app.presentationUploader.sent": "Sent",
-    "app.presentationUploader.exportingTimeout": "The exporting is taking too long...",
+    "app.presentationUploader.exportingTimeout": "The export is taking too long...",
     "app.presentationUploader.export": "Send to chat",
     "app.presentationUploader.currentPresentationLabel": "Current presentation",
     "app.presentationUploder.extraHint": "IMPORTANT: each file may not exceed {0} MB and {1} pages.",


### PR DESCRIPTION
Fixes the issue where the PDF export of presentations that are not current fail.
Includes the presentation ID in the notification message to the UI.

As requested in [#15412](https://github.com/bigbluebutton/bigbluebutton/pull/15412).